### PR TITLE
[Feature] 통합 검색 명령어 구현 - 이슈 #40

### DIFF
--- a/internal/api/nlic.go
+++ b/internal/api/nlic.go
@@ -117,7 +117,7 @@ func (c *NLICClient) Search(ctx context.Context, req *UnifiedSearchRequest) (*Se
 			bodyStr := string(body)
 			if strings.HasPrefix(strings.TrimSpace(bodyStr), "<!DOCTYPE") || strings.HasPrefix(strings.TrimSpace(bodyStr), "<html") {
 				// Parse HTML error message
-				errorMsg := ParseHTMLError(bodyStr)
+				errorMsg := c.parseHTMLError(bodyStr)
 				logger.Debug("HTML error response detected: %s", errorMsg)
 				// Check if it's an API key error
 				if strings.Contains(errorMsg, "API 인증 실패") || strings.Contains(errorMsg, "API 키") {

--- a/internal/api/nlic_test.go
+++ b/internal/api/nlic_test.go
@@ -20,12 +20,14 @@ func TestNLICClient_Search(t *testing.T) {
 		{
 			name: "successful search",
 			responseBody: `{
-				"totalCnt": 2,
-				"page": 1,
-				"law": [
-					{"법령ID": "001", "법령명한글": "테스트법1"},
-					{"법령ID": "002", "법령명한글": "테스트법2"}
-				]
+				"LawSearch": {
+					"totalCnt": "2",
+					"page": "1",
+					"law": [
+						{"법령ID": "001", "법령명한글": "테스트법1"},
+						{"법령ID": "002", "법령명한글": "테스트법2"}
+					]
+				}
 			}`,
 			responseStatus: http.StatusOK,
 			expectedError:  false,
@@ -75,6 +77,7 @@ func TestNLICClient_Search(t *testing.T) {
 				Query:    "test",
 				PageNo:   1,
 				PageSize: 10,
+				Type:     "JSON",
 			}
 			result, err := client.Search(ctx, req)
 
@@ -372,14 +375,16 @@ func TestNLICClient_RetryLogic(t *testing.T) {
 			return
 		}
 
-		// Success response
-		response := SearchResponse{
-			TotalCount: 1,
-			Page:       1,
-			Laws: []LawInfo{
-				{
-					ID:   "001",
-					Name: "Test Law",
+		// Success response with LawSearch wrapper for JSON format
+		response := map[string]interface{}{
+			"LawSearch": map[string]interface{}{
+				"totalCnt": "1",
+				"page":     "1",
+				"law": []map[string]string{
+					{
+						"법령ID":     "001",
+						"법령명한글": "Test Law",
+					},
 				},
 			},
 		}
@@ -403,6 +408,7 @@ func TestNLICClient_RetryLogic(t *testing.T) {
 		Query:    "test",
 		PageNo:   1,
 		PageSize: 10,
+		Type:     "JSON",
 	}
 
 	// Should succeed after retries

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -29,7 +29,10 @@ func initRootCmd() {
 		Use:   "warp",
 		Short: i18n.T("cli.short"),
 		Long:  i18n.T("cli.long"),
-		Example: `  # 법령 검색
+		Example: `  # 통합 검색
+  warp search "개인정보"
+  
+  # 법령 검색
   warp law "개인정보 보호법"
   
   # JSON 형식으로 출력
@@ -66,6 +69,7 @@ func Execute() {
 	initPrecedentCmd()
 	initAdmruleCmd()
 	initInterpretationCmd()
+	initSearchCmd()
 
 	// Add version command to root
 	rootCmd.AddCommand(versionCmd)
@@ -99,6 +103,9 @@ func Execute() {
 
 	// Add legal interpretation command to root
 	rootCmd.AddCommand(interpretationCmd)
+
+	// Add unified search command to root
+	rootCmd.AddCommand(searchCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -138,6 +145,7 @@ func updateCommandDescriptions() {
 	updatePrecedentCommand()
 	updateAdmruleCommand()
 	updateInterpretationCommand()
+	updateSearchCommand()
 }
 
 func init() {

--- a/internal/cmd/search.go
+++ b/internal/cmd/search.go
@@ -1,0 +1,238 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/pyhub-apps/pyhub-warp-cli/internal/api"
+	cliErrors "github.com/pyhub-apps/pyhub-warp-cli/internal/errors"
+	"github.com/pyhub-apps/pyhub-warp-cli/internal/logger"
+	"github.com/pyhub-apps/pyhub-warp-cli/internal/onboarding"
+	"github.com/pyhub-apps/pyhub-warp-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var (
+	searchOutputFormat string
+	searchPageNo       int
+	searchPageSize     int
+	searchSource       string // "all", "law", "ordinance"
+	searchRegion       string
+	searchSort         string
+
+	// testSearchClient allows injecting a mock client for testing
+	testSearchClient api.ClientInterface
+)
+
+// searchCmd represents the unified search command
+var searchCmd *cobra.Command
+
+// initSearchCmd initializes the search command
+func initSearchCmd() {
+	searchCmd = &cobra.Command{
+		Use:   "search <검색어>",
+		Short: "법령 및 자치법규 통합 검색",
+		Long: `법령(국가법령)과 자치법규를 동시에 검색합니다.
+
+UnifiedClient를 사용하여 병렬로 검색을 수행하며,
+결과를 통합하여 표시합니다.`,
+		Example: `  # 모든 소스에서 검색
+  warp search "개인정보"
+  
+  # 국가법령만 검색
+  warp search "개인정보" --source law
+  
+  # 자치법규만 검색
+  warp search "주차" --source ordinance
+  
+  # 서울 지역 포함 검색
+  warp search "주차" --region 서울
+  
+  # JSON 형식으로 출력
+  warp search "도로교통법" --format json`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: runSearchCommand,
+	}
+
+	// Add flags
+	searchCmd.Flags().StringVarP(&searchOutputFormat, "format", "f", "table", "출력 형식 (table, json, markdown, csv, html, html-simple)")
+	searchCmd.Flags().IntVarP(&searchPageNo, "page", "p", 1, "페이지 번호")
+	searchCmd.Flags().IntVarP(&searchPageSize, "size", "s", 50, "페이지 크기")
+	searchCmd.Flags().StringVar(&searchSource, "source", "all", "검색 대상 (all, law, ordinance)")
+	searchCmd.Flags().StringVarP(&searchRegion, "region", "r", "", "지역 필터 (자치법규용)")
+	searchCmd.Flags().StringVar(&searchSort, "sort", "date", "정렬 순서 (date: 날짜순, name: 이름순)")
+}
+
+// updateSearchCommand updates search command descriptions
+func updateSearchCommand() {
+	if searchCmd != nil {
+		searchCmd.Short = "법령 및 자치법규 통합 검색"
+		searchCmd.Long = `법령(국가법령)과 자치법규를 동시에 검색합니다.
+
+UnifiedClient를 사용하여 병렬로 검색을 수행하며,
+결과를 통합하여 표시합니다.`
+
+		// Update flag descriptions
+		if flag := searchCmd.Flags().Lookup("format"); flag != nil {
+			flag.Usage = "출력 형식 (table, json, markdown, csv, html, html-simple)"
+		}
+		if flag := searchCmd.Flags().Lookup("page"); flag != nil {
+			flag.Usage = "페이지 번호"
+		}
+		if flag := searchCmd.Flags().Lookup("size"); flag != nil {
+			flag.Usage = "페이지 크기"
+		}
+		if flag := searchCmd.Flags().Lookup("source"); flag != nil {
+			flag.Usage = "검색 대상 (all, law, ordinance)"
+		}
+		if flag := searchCmd.Flags().Lookup("region"); flag != nil {
+			flag.Usage = "지역 필터 (자치법규용)"
+		}
+		if flag := searchCmd.Flags().Lookup("sort"); flag != nil {
+			flag.Usage = "정렬 순서 (date: 날짜순, name: 이름순)"
+		}
+	}
+}
+
+// runSearchCommand handles the unified search command
+func runSearchCommand(cmd *cobra.Command, args []string) error {
+	// Get search query
+	query := strings.TrimSpace(strings.Join(args, " "))
+	if query == "" {
+		logger.Debug("Empty query provided")
+		return cliErrors.ErrEmptyQuery
+	}
+
+	logger.Debug("Starting unified search for query: %s", query)
+
+	// Get verbose flag from root command
+	verbose, _ := cmd.Root().Flags().GetBool("verbose")
+
+	// Use test client if available (for testing)
+	var client api.ClientInterface
+	if testSearchClient != nil {
+		client = testSearchClient
+	} else {
+		// Determine which client to create based on source flag
+		var apiType api.APIType
+		switch searchSource {
+		case "law":
+			apiType = api.APITypeNLIC
+		case "ordinance":
+			apiType = api.APITypeELIS
+		case "all":
+			apiType = api.APITypeAll
+		default:
+			return fmt.Errorf("잘못된 검색 대상: %s (all, law, ordinance 중 선택)", searchSource)
+		}
+
+		// Create appropriate API client
+		apiClient, err := api.CreateClient(apiType)
+		if err != nil {
+			// Check if it's an API key error
+			var cliErr *cliErrors.CLIError
+			if errors.As(err, &cliErr) && cliErr.Code == cliErrors.ErrCodeNoAPIKey {
+				guide := onboarding.NewGuideWithWriter(cmd.OutOrStdout(), false)
+				guide.ShowAPIKeySetup()
+				return nil
+			}
+
+			// Also check for direct API key error message
+			if strings.Contains(err.Error(), "API 키가 설정되지 않았습니다") {
+				guide := onboarding.NewGuideWithWriter(cmd.OutOrStdout(), false)
+				guide.ShowAPIKeySetup()
+				return nil
+			}
+
+			logger.LogError(err, verbose)
+			return err
+		}
+		client = apiClient
+	}
+
+	// Log search parameters
+	if searchSource == "all" {
+		logger.Info("통합 검색 중... (검색어: %s, 페이지: %d, 크기: %d)", query, searchPageNo, searchPageSize)
+	} else {
+		logger.Info("검색 중... (검색어: %s, 대상: %s, 페이지: %d, 크기: %d)", query, searchSource, searchPageNo, searchPageSize)
+	}
+	
+	if searchRegion != "" {
+		logger.Info("지역 필터 적용: %s", searchRegion)
+	}
+
+	// Create search request
+	req := &api.UnifiedSearchRequest{
+		Query:    query,
+		PageNo:   searchPageNo,
+		PageSize: searchPageSize,
+		Region:   searchRegion,
+		Sort:     searchSort,
+		Type:     "JSON", // Use JSON for unified search
+	}
+
+	// Search
+	ctx := context.Background()
+	response, err := client.Search(ctx, req)
+	if err != nil {
+		// Check if it's an API key error
+		var apiKeyErr *api.APIKeyError
+		if errors.As(err, &apiKeyErr) {
+			// If API returns an API key error, show setup guide
+			guide := onboarding.NewGuideWithWriter(cmd.OutOrStdout(), false)
+			guide.ShowAPIKeySetup()
+			return nil
+		}
+
+		logger.LogError(err, verbose)
+		return fmt.Errorf("검색 실패: %w", err)
+	}
+
+	// Log completion
+	logger.Info("검색 완료: %d개의 결과 (페이지: %d, 크기: %d)", response.TotalCount, searchPageNo, searchPageSize)
+
+	// Output results
+	return outputSearchResults(response, query, searchOutputFormat, searchPageNo, searchPageSize, cmd.OutOrStdout())
+}
+
+// outputSearchResults outputs search results in the specified format
+func outputSearchResults(response *api.SearchResponse, query, format string, pageNo, pageSize int, writer io.Writer) error {
+	if writer == nil {
+		writer = os.Stdout
+	}
+
+	// Print summary
+	fmt.Fprintf(writer, "총 %d개의 법령을 찾았습니다.\n\n", response.TotalCount)
+
+	if response.TotalCount == 0 {
+		fmt.Fprintln(writer, "검색 결과가 없습니다.")
+		return nil
+	}
+
+	// Create formatter
+	formatter := output.NewFormatter(format)
+
+	// Format and output
+	formattedOutput, err := formatter.FormatSearchResultToString(response)
+	if err != nil {
+		return fmt.Errorf("출력 형식 생성 실패: %w", err)
+	}
+
+	fmt.Fprint(writer, formattedOutput)
+
+	// Print pagination info for table format
+	if format == "table" && response.TotalCount > pageSize {
+		totalPages := (response.TotalCount + pageSize - 1) / pageSize
+		fmt.Fprintf(writer, "\n페이지 %d/%d (--page 옵션으로 다른 페이지 조회 가능)\n", pageNo, totalPages)
+	}
+
+	return nil
+}
+
+func init() {
+	// Search command will be initialized and added in Execute()
+}


### PR DESCRIPTION
## 📋 개요
법령과 자치법규를 동시에 검색할 수 있는 통합 검색 명령어 구현

## 🚀 주요 변경사항

### 1. 새로운 명령어 추가
- `warp search` 명령어 구현
- UnifiedClient를 활용한 병렬 검색

### 2. 플래그 옵션
- `--source <all|law|ordinance>` - 검색 대상 선택 
- `--region <지역명>` - 지역 필터 (자치법규용)
- `--format` - 출력 형식 선택
- `--page`, `--size` - 페이지네이션

### 3. API 개선
- NLIC JSON 응답 파싱 수정
  - LawSearch wrapper 구조체 추가
  - JSON/XML 형식 모두 지원

## ✅ 테스트 결과

### 통합 검색
```bash
$ ./warp search "개인정보" --size 5
총 206개의 법령을 찾았습니다.
# 국가법령과 자치법규가 함께 표시됨
```

### 소스별 필터링
```bash
# 법령만 검색
$ ./warp search "개인정보" --source law --size 5
총 12개의 법령을 찾았습니다.

# 자치법규만 검색  
$ ./warp search "개인정보" --source ordinance --size 5
총 194개의 법령을 찾았습니다.
```

### 지역 필터
```bash
$ ./warp search "주차" --region "서울" --size 5
총 152개의 법령을 찾았습니다.
# 서울 지역 자치법규 + 관련 국가법령 표시
```

## 📊 성능
- 병렬 검색으로 빠른 응답 속도
- NLIC와 ELIS API를 동시에 호출
- 결과 병합 및 정렬 자동 처리

## 🔧 기술적 세부사항

### UnifiedClient 활용
- 기존 구현된 UnifiedClient 활용
- 병렬 검색 및 결과 병합 로직 그대로 사용
- Source 정보 추가하여 출처 구분

### API 호환성
- NLIC: JSON/XML 모두 지원
- ELIS: JSON 형식 사용
- 통합 검색: JSON 형식 통일

## 📝 관련 이슈
- Fixes #40 - 통합 검색 명령어 구현
- Related to #28 - ELIS API 통합 (완료됨)

## 🧪 체크리스트
- [x] 통합 검색 작동 확인
- [x] 소스별 필터링 테스트
- [x] 지역 필터 테스트
- [x] 다양한 출력 형식 테스트
- [x] 페이지네이션 확인
- [x] 에러 처리 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified search command to query national laws and local ordinances together or separately; supports format, page, size, source, region, sort; improved formatted outputs and pagination hint.

* **Bug Fixes**
  * Robust JSON parsing for wrapped law-search responses; page defaults sensibly when API omits it; HTML/XML fallbacks preserved.

* **Tests**
  * Updated tests to exercise the wrapped JSON response format and JSON search path.

* **Documentation**
  * CLI examples updated to include unified search usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->