### PR TITLE
fix: 기존 테스트 실패 수정

### DIFF
--- a/internal/api/admrul.go
+++ b/internal/api/admrul.go
@@ -104,7 +104,7 @@ func (c *AdmrulClient) Search(ctx context.Context, req *UnifiedSearchRequest) (*
 		logger.Debug("JSON format not supported for administrative rule API, returning empty result")
 		return &SearchResponse{TotalCount: 0, Page: req.PageNo, Laws: []LawInfo{}}, nil
 	}
-	
+
 	// Parse XML response
 	var admrulResponse AdmrulSearchResponse
 	if err := xml.Unmarshal(body, &admrulResponse); err != nil {

--- a/internal/api/elis.go
+++ b/internal/api/elis.go
@@ -31,7 +31,7 @@ func NewELISClient(apiKey string) *ELISClient {
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		baseURL:        "https://www.law.go.kr/DRF/lawSearch.do", // 자치법규 목록
+		baseURL:        "https://www.law.go.kr/DRF/lawSearch.do",  // 자치법규 목록
 		detailURL:      "https://www.law.go.kr/DRF/lawService.do", // 자치법규 본문
 		apiKey:         apiKey,
 		retryBaseDelay: 500 * time.Millisecond,
@@ -79,14 +79,14 @@ func (c *ELISClient) Search(ctx context.Context, req *UnifiedSearchRequest) (*Se
 	params := url.Values{}
 	params.Set("OC", c.apiKey)
 	params.Set("target", "ordin") // 자치법규 대상
-	
+
 	// Add region to query if provided
 	query := req.Query
 	if req.Region != "" {
 		query = req.Region + " " + query
 	}
 	params.Set("query", query)
-	
+
 	params.Set("page", fmt.Sprintf("%d", req.PageNo))
 	params.Set("display", fmt.Sprintf("%d", req.PageSize))
 	params.Set("type", "json")
@@ -151,7 +151,7 @@ func (c *ELISClient) Search(ctx context.Context, req *UnifiedSearchRequest) (*Se
 		law := LawInfo{
 			LawType: "자치법규",
 		}
-		
+
 		// Parse fields from map
 		if v, ok := lawData["자치법규ID"].(string); ok {
 			law.ID = v
@@ -177,7 +177,7 @@ func (c *ELISClient) Search(ctx context.Context, req *UnifiedSearchRequest) (*Se
 		if v, ok := lawData["시행일자"].(string); ok {
 			law.EffectDate = v
 		}
-		
+
 		searchResp.Laws = append(searchResp.Laws, law)
 	}
 

--- a/internal/api/expc.go
+++ b/internal/api/expc.go
@@ -24,13 +24,13 @@ type ExpcSearchResponse struct {
 
 // ExpcInfo represents individual legal interpretation information
 type ExpcInfo struct {
-	ID             string `xml:"법령해석례일련번호"`
-	Title          string `xml:"안건명"`
-	CaseNumber     string `xml:"안건번호"`
-	QueryDept      string `xml:"질의기관명"`
-	ResponseDept   string `xml:"회신기관명"`
-	ResponseDate   string `xml:"회신일자"`
-	DetailLink     string `xml:"법령해석례상세링크"`
+	ID           string `xml:"법령해석례일련번호"`
+	Title        string `xml:"안건명"`
+	CaseNumber   string `xml:"안건번호"`
+	QueryDept    string `xml:"질의기관명"`
+	ResponseDept string `xml:"회신기관명"`
+	ResponseDate string `xml:"회신일자"`
+	DetailLink   string `xml:"법령해석례상세링크"`
 }
 
 // ExpcClient represents the Legal Interpretation API client (법령해석례 API 클라이언트)
@@ -98,7 +98,6 @@ func (c *ExpcClient) Search(ctx context.Context, req *UnifiedSearchRequest) (*Se
 	if err != nil {
 		return nil, err
 	}
-	
 
 	// Parse response based on type
 	if strings.ToUpper(req.Type) == "JSON" {
@@ -106,14 +105,13 @@ func (c *ExpcClient) Search(ctx context.Context, req *UnifiedSearchRequest) (*Se
 		logger.Debug("JSON format not supported for legal interpretation API, returning empty result")
 		return &SearchResponse{TotalCount: 0, Page: req.PageNo, Laws: []LawInfo{}}, nil
 	}
-	
+
 	// Parse XML response
 	var expcResponse ExpcSearchResponse
 	if err := xml.Unmarshal(body, &expcResponse); err != nil {
 		logger.Error("XML parsing failed: %v", err)
 		return nil, fmt.Errorf("XML 파싱 실패: %w", err)
 	}
-
 
 	// Convert to SearchResponse
 	response := &SearchResponse{
@@ -126,7 +124,7 @@ func (c *ExpcClient) Search(ctx context.Context, req *UnifiedSearchRequest) (*Se
 		response.Laws[i] = LawInfo{
 			ID:         expc.ID,
 			Name:       expc.Title,
-			LawType:    "법령해석례",  // Legal interpretation type
+			LawType:    "법령해석례", // Legal interpretation type
 			Department: expc.QueryDept,
 			PromulDate: expc.ResponseDate,
 			PromulNo:   expc.CaseNumber,

--- a/internal/api/nlic.go
+++ b/internal/api/nlic.go
@@ -181,9 +181,9 @@ func (c *NLICClient) GetDetail(ctx context.Context, lawID string) (*LawDetail, e
 		LawInfo: LawInfo{
 			SerialNo: lawID, // Use the provided law ID
 		},
-		Articles:                 make([]Article, 0),
-		Tables:                   make([]Table, 0),
-		SupplementaryProvisions:  make([]SupplementaryProvision, 0),
+		Articles:                make([]Article, 0),
+		Tables:                  make([]Table, 0),
+		SupplementaryProvisions: make([]SupplementaryProvision, 0),
 	}
 
 	// Extract basic info if available
@@ -195,12 +195,12 @@ func (c *NLICClient) GetDetail(ctx context.Context, lawID string) (*LawDetail, e
 		detail.LawInfo.PromulNo = basicInfo.PromulgationNumber
 		detail.LawInfo.EffectDate = basicInfo.EffectiveDate
 		detail.LawInfo.Category = basicInfo.RevisionType
-		
+
 		// Extract department info if available
 		if basicInfo.Department.Content != "" {
 			detail.LawInfo.Department = basicInfo.Department.Content
 		}
-		
+
 		// Extract law type info if available
 		if basicInfo.LawTypeInfo.Content != "" {
 			detail.LawInfo.LawType = basicInfo.LawTypeInfo.Content
@@ -225,7 +225,7 @@ func (c *NLICClient) GetDetail(ctx context.Context, lawID string) (*LawDetail, e
 			Number: unit.TableNumber,
 			Title:  unit.TableTitle,
 		}
-		
+
 		// Handle table content which can be string or array
 		if unit.TableContent != nil {
 			if tableStr, ok := unit.TableContent.(string); ok {
@@ -235,7 +235,7 @@ func (c *NLICClient) GetDetail(ctx context.Context, lawID string) (*LawDetail, e
 				table.Content = "(별표 내용 있음)"
 			}
 		}
-		
+
 		detail.Tables = append(detail.Tables, table)
 	}
 
@@ -245,7 +245,7 @@ func (c *NLICClient) GetDetail(ctx context.Context, lawID string) (*LawDetail, e
 			Number:           unit.ProvisionNumber,
 			PromulgationDate: unit.ProvisionDate,
 		}
-		
+
 		// Handle provision content which can be string or array
 		if unit.ProvisionContent != nil {
 			if provStr, ok := unit.ProvisionContent.(string); ok {
@@ -264,7 +264,7 @@ func (c *NLICClient) GetDetail(ctx context.Context, lawID string) (*LawDetail, e
 				supp.Content = "(부칙 내용 있음)"
 			}
 		}
-		
+
 		detail.SupplementaryProvisions = append(detail.SupplementaryProvisions, supp)
 	}
 
@@ -277,7 +277,7 @@ func (c *NLICClient) GetDetail(ctx context.Context, lawID string) (*LawDetail, e
 			EffectDate: unit.ArticleEffectDate,
 		}
 		detail.Articles = append(detail.Articles, article)
-		
+
 		// If basic info wasn't in the main structure, try to get from article units
 		if detail.LawInfo.ID == "" && unit.LawID != "" {
 			detail.LawInfo.ID = unit.LawID
@@ -488,7 +488,7 @@ func (c *NLICClient) parseHTMLError(html string) string {
 	if strings.Contains(html, "미신청된 목록/본문에 대한 접근입니다") {
 		return "API 사용 권한이 없습니다. https://open.law.go.kr 에서 로그인 후 [OPEN API] -> [OPEN API 신청]에서 필요한 법령 종류를 체크해주세요"
 	}
-	
+
 	if strings.Contains(html, "페이지 접속에 실패하였습니다") {
 		return "API 접속 실패: API 키를 확인하거나 서비스 상태를 점검해주세요"
 	}

--- a/internal/api/prec.go
+++ b/internal/api/prec.go
@@ -102,7 +102,7 @@ func (c *PrecClient) Search(ctx context.Context, req *UnifiedSearchRequest) (*Se
 		logger.Debug("JSON format not supported for precedent API, returning empty result")
 		return &SearchResponse{TotalCount: 0, Page: req.PageNo, Laws: []LawInfo{}}, nil
 	}
-	
+
 	// Parse XML response
 	var precResponse PrecSearchResponse
 	if err := xml.Unmarshal(body, &precResponse); err != nil {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -52,14 +52,14 @@ type UnifiedSearchRequest struct {
 // LawDetail represents detailed law information
 type LawDetail struct {
 	LawInfo
-	Content              string                 `json:"조문내용" xml:"조문내용"`
-	Articles             []Article              `json:"조문" xml:"조문"`
-	Attachments          []string               `json:"첨부파일" xml:"첨부파일"`
-	RelatedLaws          []string               `json:"관련법령" xml:"관련법령"`
-	RevisionText         string                 `json:"개정문" xml:"개정문"`        // 개정문 내용
-	Tables               []Table                `json:"별표" xml:"별표"`          // 별표 목록
-	SupplementaryProvisions []SupplementaryProvision `json:"부칙" xml:"부칙"` // 부칙 목록
-	HasRevisionText      bool                   `json:"개정문존재" xml:"개정문존재"`  // 개정문 존재 여부
+	Content                 string                   `json:"조문내용" xml:"조문내용"`
+	Articles                []Article                `json:"조문" xml:"조문"`
+	Attachments             []string                 `json:"첨부파일" xml:"첨부파일"`
+	RelatedLaws             []string                 `json:"관련법령" xml:"관련법령"`
+	RevisionText            string                   `json:"개정문" xml:"개정문"`     // 개정문 내용
+	Tables                  []Table                  `json:"별표" xml:"별표"`       // 별표 목록
+	SupplementaryProvisions []SupplementaryProvision `json:"부칙" xml:"부칙"`       // 부칙 목록
+	HasRevisionText         bool                     `json:"개정문존재" xml:"개정문존재"` // 개정문 존재 여부
 }
 
 // LawDetailResponse represents the actual API response structure for law detail
@@ -69,26 +69,26 @@ type LawDetailResponse struct {
 
 // LawDetailContent represents the content structure returned by the detail API
 type LawDetailContent struct {
-	LawKey      string           `json:"법령키" xml:"법령키"`
-	BasicInfo   *BasicInfo       `json:"기본정보" xml:"기본정보"`
-	Revisions   RevisionContent  `json:"개정문" xml:"개정문"`
-	Tables      TableContent     `json:"별표" xml:"별표"`
-	ArticlesRaw ArticlesContent  `json:"조문" xml:"조문"`
+	LawKey                  string                         `json:"법령키" xml:"법령키"`
+	BasicInfo               *BasicInfo                     `json:"기본정보" xml:"기본정보"`
+	Revisions               RevisionContent                `json:"개정문" xml:"개정문"`
+	Tables                  TableContent                   `json:"별표" xml:"별표"`
+	ArticlesRaw             ArticlesContent                `json:"조문" xml:"조문"`
 	SupplementaryProvisions SupplementaryProvisionsContent `json:"부칙" xml:"부칙"`
 }
 
 // BasicInfo represents basic law information
 type BasicInfo struct {
-	LawID              string          `json:"법령ID" xml:"법령ID"`
-	LawNameKorean      string          `json:"법령명_한글" xml:"법령명_한글"`
-	LawNameHanja       string          `json:"법령명_한자" xml:"법령명_한자"`
-	LawNameAbbr        string          `json:"법령명약칭" xml:"법령명약칭"`
-	PromulgationDate   string          `json:"공포일자" xml:"공포일자"`
-	PromulgationNumber string          `json:"공포번호" xml:"공포번호"`
-	EffectiveDate      string          `json:"시행일자" xml:"시행일자"`
-	RevisionType       string          `json:"제개정구분" xml:"제개정구분"`
-	Department         DepartmentInfo  `json:"소관부처" xml:"소관부처"`
-	LawTypeInfo        LawTypeInfo     `json:"법종구분" xml:"법종구분"`
+	LawID              string         `json:"법령ID" xml:"법령ID"`
+	LawNameKorean      string         `json:"법령명_한글" xml:"법령명_한글"`
+	LawNameHanja       string         `json:"법령명_한자" xml:"법령명_한자"`
+	LawNameAbbr        string         `json:"법령명약칭" xml:"법령명약칭"`
+	PromulgationDate   string         `json:"공포일자" xml:"공포일자"`
+	PromulgationNumber string         `json:"공포번호" xml:"공포번호"`
+	EffectiveDate      string         `json:"시행일자" xml:"시행일자"`
+	RevisionType       string         `json:"제개정구분" xml:"제개정구분"`
+	Department         DepartmentInfo `json:"소관부처" xml:"소관부처"`
+	LawTypeInfo        LawTypeInfo    `json:"법종구분" xml:"법종구분"`
 }
 
 // DepartmentInfo represents department information
@@ -149,23 +149,22 @@ type ArticlesContent struct {
 
 // ArticleUnit represents a single article unit from the API
 type ArticleUnit struct {
-	ArticleKey          string      `json:"조문키" xml:"조문키"`
-	ArticleNumber       string      `json:"조문번호" xml:"조문번호"`
-	ArticleYN           string      `json:"조문여부" xml:"조문여부"`
-	ArticleContent      string      `json:"조문내용" xml:"조문내용"`
-	ArticleReference    string      `json:"조문참고자료" xml:"조문참고자료"`
-	ArticleEffectDate   string      `json:"조문시행일자" xml:"조문시행일자"`
-	ArticleTitle        string      `json:"조문제목" xml:"조문제목"`
-	ArticleChangeYN     string      `json:"조문변경여부" xml:"조문변경여부"`
-	ArticleMoveBefore   string      `json:"조문이동이전" xml:"조문이동이전"`
-	ArticleMoveAfter    string      `json:"조문이동이후" xml:"조문이동이후"`
-	Paragraphs          interface{} `json:"항" xml:"항"` // Can be array or object
-	ArticleHistory      interface{} `json:"조문이동이력" xml:"조문이동이력"`
-	LawID               string      `json:"법령ID" xml:"법령ID"`
-	LawNameKorean       string      `json:"법령명한글" xml:"법령명한글"`
-	LawSerialNo         string      `json:"법령일련번호" xml:"법령일련번호"`
+	ArticleKey        string      `json:"조문키" xml:"조문키"`
+	ArticleNumber     string      `json:"조문번호" xml:"조문번호"`
+	ArticleYN         string      `json:"조문여부" xml:"조문여부"`
+	ArticleContent    string      `json:"조문내용" xml:"조문내용"`
+	ArticleReference  string      `json:"조문참고자료" xml:"조문참고자료"`
+	ArticleEffectDate string      `json:"조문시행일자" xml:"조문시행일자"`
+	ArticleTitle      string      `json:"조문제목" xml:"조문제목"`
+	ArticleChangeYN   string      `json:"조문변경여부" xml:"조문변경여부"`
+	ArticleMoveBefore string      `json:"조문이동이전" xml:"조문이동이전"`
+	ArticleMoveAfter  string      `json:"조문이동이후" xml:"조문이동이후"`
+	Paragraphs        interface{} `json:"항" xml:"항"` // Can be array or object
+	ArticleHistory    interface{} `json:"조문이동이력" xml:"조문이동이력"`
+	LawID             string      `json:"법령ID" xml:"법령ID"`
+	LawNameKorean     string      `json:"법령명한글" xml:"법령명한글"`
+	LawSerialNo       string      `json:"법령일련번호" xml:"법령일련번호"`
 }
-
 
 // SupplementaryProvision represents a supplementary provision (부칙)
 type SupplementaryProvision struct {

--- a/internal/cmd/law_test.go
+++ b/internal/cmd/law_test.go
@@ -131,8 +131,8 @@ func TestLawCommandFlags(t *testing.T) {
 	}
 
 	sizeFlag := lawCmd.Flag("size")
-	if sizeFlag.DefValue != "10" {
-		t.Errorf("size flag default = %s, want 10", sizeFlag.DefValue)
+	if sizeFlag.DefValue != "50" {
+		t.Errorf("size flag default = %s, want 50", sizeFlag.DefValue)
 	}
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,7 +17,6 @@ var (
 	Version   = "dev"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
-
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -109,7 +108,6 @@ func Execute() {
 func setupFlags() {
 	// Initialize configuration
 	cobra.OnInitialize(initConfig)
-
 
 	// Global flags
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, i18n.T("cli.verbose"))

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -43,13 +43,11 @@ func Init() error {
 	return nil
 }
 
-
 // detectLanguage always returns Korean as this is a Korean law information tool
 func detectLanguage() string {
 	// Always return Korean - this is a Korean law information tool
 	return "ko"
 }
-
 
 // T translates a message
 func T(messageID string, data ...map[string]interface{}) string {

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -281,37 +281,37 @@ func (f *Formatter) formatDetailTableWithOptions(detail *api.LawDetail, showArti
 	} else if detail.SerialNo != "" {
 		fmt.Fprintf(&buf, "법령일련번호: %s\n", detail.SerialNo)
 	}
-	
+
 	if detail.Name != "" {
 		fmt.Fprintf(&buf, "법령명:       %s\n", detail.Name)
 	} else {
 		fmt.Fprintf(&buf, "법령명:       (정보 없음)\n")
 	}
-	
+
 	if detail.NameAbbrev != "" {
 		fmt.Fprintf(&buf, "약칭:         %s\n", detail.NameAbbrev)
 	}
-	
+
 	if detail.LawType != "" {
 		fmt.Fprintf(&buf, "법령구분:     %s\n", detail.LawType)
 	}
-	
+
 	if detail.Department != "" {
 		fmt.Fprintf(&buf, "소관부처:     %s\n", detail.Department)
 	}
-	
+
 	if detail.PromulDate != "" {
 		fmt.Fprintf(&buf, "공포일자:     %s\n", formatDate(detail.PromulDate))
 	}
-	
+
 	if detail.PromulNo != "" {
 		fmt.Fprintf(&buf, "공포번호:     %s\n", detail.PromulNo)
 	}
-	
+
 	if detail.EffectDate != "" {
 		fmt.Fprintf(&buf, "시행일자:     %s\n", formatDate(detail.EffectDate))
 	}
-	
+
 	if detail.Category != "" {
 		fmt.Fprintf(&buf, "제개정구분:   %s\n", detail.Category)
 	}

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -411,7 +411,7 @@ func TestFormatTableToString(t *testing.T) {
 			},
 		},
 		{
-			name: "Long names truncated",
+			name: "Long names wrapped",
 			resp: &api.SearchResponse{
 				TotalCount: 1,
 				Page:       1,
@@ -425,7 +425,9 @@ func TestFormatTableToString(t *testing.T) {
 				},
 			},
 			contains: []string{
-				"...", // Should have ellipsis for truncated text
+				"매우 긴 법령 이름입니다",  // Text should be wrapped, not truncated
+				"이것은 정말로 너무 길어서", // Second line of wrapped text
+				"매우 긴 부처명입니다",      // Department text wrapped
 			},
 		},
 		{

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -427,7 +427,7 @@ func TestFormatTableToString(t *testing.T) {
 			contains: []string{
 				"매우 긴 법령 이름입니다",  // Text should be wrapped, not truncated
 				"이것은 정말로 너무 길어서", // Second line of wrapped text
-				"매우 긴 부처명입니다",      // Department text wrapped
+				"매우 긴 부처명입니다",    // Department text wrapped
 			},
 		},
 		{

--- a/internal/output/table_writer.go
+++ b/internal/output/table_writer.go
@@ -14,9 +14,9 @@ import (
 
 // TableStyle defines the style for table output
 type TableStyle struct {
-	UseColor    bool
-	Compact     bool
-	BoxDrawing  bool
+	UseColor      bool
+	Compact       bool
+	BoxDrawing    bool
 	TerminalWidth int
 }
 
@@ -24,14 +24,14 @@ type TableStyle struct {
 func GetDefaultTableStyle() *TableStyle {
 	// Check if output is to a terminal
 	useColor := isTerminal()
-	
+
 	// Get terminal width
 	width := getTerminalWidth()
-	
+
 	return &TableStyle{
-		UseColor:    useColor,
-		Compact:     false,
-		BoxDrawing:  true,
+		UseColor:      useColor,
+		Compact:       false,
+		BoxDrawing:    true,
 		TerminalWidth: width,
 	}
 }
@@ -61,7 +61,7 @@ func RenderTable(headers []string, rows [][]string, style *TableStyle) string {
 
 	var buf bytes.Buffer
 	table := tablewriter.NewWriter(&buf)
-	
+
 	// Set headers
 	if style.UseColor {
 		coloredHeaders := make([]string, len(headers))
@@ -72,7 +72,7 @@ func RenderTable(headers []string, rows [][]string, style *TableStyle) string {
 	} else {
 		table.SetHeader(headers)
 	}
-	
+
 	// Configure table style
 	if style.BoxDrawing {
 		table.SetBorder(true)
@@ -85,41 +85,41 @@ func RenderTable(headers []string, rows [][]string, style *TableStyle) string {
 		table.SetRowLine(false)
 		table.SetHeaderLine(true)
 	}
-	
+
 	// Set alignment
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-	
+
 	// Auto wrap and merge for long content
 	table.SetAutoWrapText(true)
 	table.SetAutoFormatHeaders(true)
 	table.SetReflowDuringAutoWrap(true)
-	
+
 	// Add rows
 	for _, row := range rows {
 		table.Append(row)
 	}
-	
+
 	// Render
 	table.Render()
-	
+
 	return buf.String()
 }
 
 // RenderMarkdownTable renders a markdown table
 func RenderMarkdownTable(headers []string, rows [][]string) string {
 	var buf bytes.Buffer
-	
+
 	// Write headers
 	fmt.Fprintf(&buf, "| %s |\n", strings.Join(headers, " | "))
-	
+
 	// Write separator
 	separators := make([]string, len(headers))
 	for i := range separators {
 		separators[i] = "---"
 	}
 	fmt.Fprintf(&buf, "| %s |\n", strings.Join(separators, " | "))
-	
+
 	// Write rows
 	for _, row := range rows {
 		// Escape pipe characters in content
@@ -129,83 +129,83 @@ func RenderMarkdownTable(headers []string, rows [][]string) string {
 		}
 		fmt.Fprintf(&buf, "| %s |\n", strings.Join(escapedRow, " | "))
 	}
-	
+
 	return buf.String()
 }
 
 // RenderCSV renders data as CSV
 func RenderCSV(headers []string, rows [][]string, withBOM bool) (string, error) {
 	var buf bytes.Buffer
-	
+
 	// Add BOM for Excel compatibility with Korean characters
 	if withBOM {
 		buf.Write([]byte{0xEF, 0xBB, 0xBF})
 	}
-	
+
 	writer := csv.NewWriter(&buf)
-	
+
 	// Write headers
 	if err := writer.Write(headers); err != nil {
 		return "", fmt.Errorf("CSV 헤더 작성 실패: %w", err)
 	}
-	
+
 	// Write rows
 	for _, row := range rows {
 		if err := writer.Write(row); err != nil {
 			return "", fmt.Errorf("CSV 데이터 작성 실패: %w", err)
 		}
 	}
-	
+
 	writer.Flush()
-	
+
 	if err := writer.Error(); err != nil {
 		return "", fmt.Errorf("CSV 작성 실패: %w", err)
 	}
-	
+
 	return buf.String(), nil
 }
 
 // RenderHTMLTable renders an HTML table
 func RenderHTMLTable(headers []string, rows [][]string) string {
 	var buf bytes.Buffer
-	
+
 	// Start table with basic styling
 	fmt.Fprintln(&buf, `<table style="border-collapse: collapse; width: 100%;">`)
-	
+
 	// Headers
 	fmt.Fprintln(&buf, "  <thead>")
 	fmt.Fprintln(&buf, "    <tr>")
 	for _, header := range headers {
-		fmt.Fprintf(&buf, `      <th style="border: 1px solid #ddd; padding: 8px; background-color: #f2f2f2; text-align: left;">%s</th>%s`, 
+		fmt.Fprintf(&buf, `      <th style="border: 1px solid #ddd; padding: 8px; background-color: #f2f2f2; text-align: left;">%s</th>%s`,
 			escapeHTML(header), "\n")
 	}
 	fmt.Fprintln(&buf, "    </tr>")
 	fmt.Fprintln(&buf, "  </thead>")
-	
+
 	// Body
 	fmt.Fprintln(&buf, "  <tbody>")
 	for _, row := range rows {
 		fmt.Fprintln(&buf, "    <tr>")
 		for _, cell := range row {
-			fmt.Fprintf(&buf, `      <td style="border: 1px solid #ddd; padding: 8px;">%s</td>%s`, 
+			fmt.Fprintf(&buf, `      <td style="border: 1px solid #ddd; padding: 8px;">%s</td>%s`,
 				escapeHTML(cell), "\n")
 		}
 		fmt.Fprintln(&buf, "    </tr>")
 	}
 	fmt.Fprintln(&buf, "  </tbody>")
-	
+
 	fmt.Fprintln(&buf, "</table>")
-	
+
 	return buf.String()
 }
 
 // RenderHTMLSimpleTable renders a simple HTML table without CSS styles
 func RenderHTMLSimpleTable(headers []string, rows [][]string) string {
 	var buf bytes.Buffer
-	
+
 	// Start table
 	fmt.Fprintln(&buf, `<table>`)
-	
+
 	// Headers
 	fmt.Fprintln(&buf, "  <thead>")
 	fmt.Fprintln(&buf, "    <tr>")
@@ -214,7 +214,7 @@ func RenderHTMLSimpleTable(headers []string, rows [][]string) string {
 	}
 	fmt.Fprintln(&buf, "    </tr>")
 	fmt.Fprintln(&buf, "  </thead>")
-	
+
 	// Body
 	fmt.Fprintln(&buf, "  <tbody>")
 	for _, row := range rows {
@@ -225,9 +225,9 @@ func RenderHTMLSimpleTable(headers []string, rows [][]string) string {
 		fmt.Fprintln(&buf, "    </tr>")
 	}
 	fmt.Fprintln(&buf, "  </tbody>")
-	
+
 	fmt.Fprintln(&buf, "</table>")
-	
+
 	return buf.String()
 }
 
@@ -246,12 +246,12 @@ func HighlightValue(value string, style *TableStyle) string {
 	if style == nil || !style.UseColor {
 		return value
 	}
-	
+
 	// Highlight dates
 	if len(value) == 10 && value[4] == '-' && value[7] == '-' {
 		return color.YellowString(value)
 	}
-	
+
 	// Highlight law types
 	switch value {
 	case "법률":

--- a/test/test_detail_api.go
+++ b/test/test_detail_api.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main


### PR DESCRIPTION
## 개요
Issue #42에서 보고된 CI/CD 파이프라인의 테스트 실패를 수정합니다.

## 수정 내용

### 1. TestLawCommandFlags
**문제**: 페이지 크기 기본값 불일치
```
law_test.go:135: size flag default = 50, want 10
```

**해결**: 테스트의 기대값을 10에서 50으로 수정
- law 명령어의 실제 기본값은 50으로 설정되어 있음
- 테스트가 구버전 기본값(10)을 기대하고 있었음

### 2. TestFormatTableToString/Long_names_truncated
**문제**: ellipsis("...") 미출력
```
Result should contain "...", got: [실제 출력]
```

**해결**: 테스트 케이스를 실제 동작에 맞게 수정
- tablewriter는 긴 텍스트를 truncate가 아닌 wrap으로 처리
- 테스트명을 "Long names wrapped"로 변경
- ellipsis 확인 대신 wrapped된 텍스트 확인

## 테스트 결과
✅ 모든 테스트 통과
```
ok  github.com/pyhub-apps/pyhub-warp-cli/cmd/warp
ok  github.com/pyhub-apps/pyhub-warp-cli/internal/api
ok  github.com/pyhub-apps/pyhub-warp-cli/internal/cmd
ok  github.com/pyhub-apps/pyhub-warp-cli/internal/config
ok  github.com/pyhub-apps/pyhub-warp-cli/internal/errors
ok  github.com/pyhub-apps/pyhub-warp-cli/internal/logger
ok  github.com/pyhub-apps/pyhub-warp-cli/internal/onboarding
ok  github.com/pyhub-apps/pyhub-warp-cli/internal/output
```

## 관련 이슈
- Fixes #42